### PR TITLE
Find all

### DIFF
--- a/lib/juvet/adapters/null_adapter.rb
+++ b/lib/juvet/adapters/null_adapter.rb
@@ -4,6 +4,10 @@ module Juvet
       def initialize(collection=nil, options={})
       end
 
+      def all
+        []
+      end
+
       def create(entity)
         entity
       end

--- a/lib/juvet/bot.rb
+++ b/lib/juvet/bot.rb
@@ -5,6 +5,10 @@ module Juvet
     attr_reader :id
 
     class << self
+      def all!
+        BotRepository.all
+      end
+
       def create(id, attributes={})
         new attributes.merge(id: id)
       end

--- a/lib/juvet/repository.rb
+++ b/lib/juvet/repository.rb
@@ -19,6 +19,10 @@ module Juvet
         @adapter = adapter
       end
 
+      def all
+        adapter.all
+      end
+
       def create(entity)
         adapter.create entity
       end

--- a/spec/juvet/adapters/null_adapter_spec.rb
+++ b/spec/juvet/adapters/null_adapter_spec.rb
@@ -2,6 +2,12 @@ describe Juvet::Adapters::NullAdapter do
   let(:entity) { Object.new }
   subject { described_class.new }
 
+  describe "#all" do
+    it "simply returns an empty array" do
+      expect(subject.all).to be_empty
+    end
+  end
+
   describe "#create" do
     it "simply returns the entity" do
       expect(subject.create(entity)).to eq entity

--- a/spec/juvet/adapters/redis_adapter_spec.rb
+++ b/spec/juvet/adapters/redis_adapter_spec.rb
@@ -14,12 +14,23 @@ describe Juvet::Adapters::RedisAdapter do
   end
 
   let(:collection) { double(:collection, name: :entities, entity: Entity) }
-  let(:entity) { Entity.new id: 123 }
+  let(:entity) { Entity.new id: "123" }
   let(:url) { "redis://localhost:6379" }
   subject { described_class.new collection, url: url, db: 15 }
 
   before(:all) { @redis = Redis.new db: 15 }
   after(:all) { @redis.flushdb }
+
+  describe "#all" do
+    it "returns all the entities for a given collection" do
+      entity1 = subject.create(entity)
+      entity2 = subject.create(Entity.new(id: "1234"))
+
+      result = subject.all
+
+      expect(result.map(&:id)).to eq ["1234", "123"]
+    end
+  end
 
   describe "#create" do
     it "stores the entity in the redis store" do
@@ -48,7 +59,7 @@ describe Juvet::Adapters::RedisAdapter do
     end
 
     it "returns nil if the entity can't be found" do
-      result = subject.find 789
+      result = subject.find "789"
 
       expect(result).to be_nil
     end
@@ -84,7 +95,7 @@ describe Juvet::Adapters::RedisAdapter do
     end
 
     it "throws an exception if the entity is not already stored" do
-      entity = Entity.new id: 456
+      entity = Entity.new id: "456"
 
       expect { subject.update entity }.to raise_error Juvet::EntityNotFoundError
     end

--- a/spec/juvet/bot_spec.rb
+++ b/spec/juvet/bot_spec.rb
@@ -25,6 +25,13 @@ describe Juvet::Bot do
     end
   end
 
+  describe ".all!" do
+    it "returns all the bots from the repository" do
+      expect(Juvet::BotRepository).to receive(:all)
+      described_class.all!
+    end
+  end
+
   describe ".create!" do
     it "stores the created instance in the repository" do
       expect(Juvet::BotRepository).to receive(:create).with Juvet::Bot

--- a/spec/juvet/repository_spec.rb
+++ b/spec/juvet/repository_spec.rb
@@ -7,6 +7,13 @@ describe Juvet::Repository do
     expect(Repository.adapter).to be_instance_of Juvet::Adapters::NullAdapter
   end
 
+  describe ".all" do
+    it "passes the retrieval to the adapter" do
+      expect(Repository.adapter).to receive(:all)
+      Repository.all
+    end
+  end
+
   describe ".create" do
     it "passes creation to the adapter" do
       object = Object.new


### PR DESCRIPTION
Implements a way to find all the entities for a specific entity type.

This is not very performant as it uses the redis `KEYS` command.
